### PR TITLE
Typo: di -> to

### DIFF
--- a/jupytemplate/jupytemplate/template.ipynb
+++ b/jupytemplate/jupytemplate/template.ipynb
@@ -177,7 +177,7 @@
    "metadata": {},
    "source": [
     "# Data processing\n",
-    "Put here the core of the notebook. Feel free di further split this section into subsections."
+    "Put here the core of the notebook. Feel free to further split this section into subsections."
    ]
   },
   {


### PR DESCRIPTION
It looks like there was a small typo in the template.

Original:
```
Feel free di further split this section into subsections.
```

Proposed Change
```
Feel free to further split this section into subsections.
```